### PR TITLE
Update fr-FR.yml and en-US.yml and fr-ME.yml

### DIFF
--- a/src/lang/en-US.yml
+++ b/src/lang/en-US.yml
@@ -170,7 +170,7 @@ remove_command_error: "Error occurred, please try again"
 remove_command_work: "Successfully removed ${member.tag} from your ticket!"
 
 # /transript
-transript_disabled_command: "You can't use this command because an Administrator disabled the ticket command !"
+transript_disabled_command: "You cannot use this command because an administrator has disabled it!"
 transript_name_sourcebin: " "
 transript_title_sourcebin: "Ticket Chat transcript for ${channel.name}"
 transript_command_error: "Error occurred, please try again!"

--- a/src/lang/fr-FR.yml
+++ b/src/lang/fr-FR.yml
@@ -120,7 +120,7 @@ add_command_work: "Membre ${member.tag} ajouté avec succès au ticket!"
 add_command_error: "Une erreur est survenue, veuillez réessayer."
 
 # /close
-close_disabled_command: "Vous ne pouvez pas utiliser cette commande car un administrateur a désactivé cette commande !"
+close_disabled_command: "Vous ne pouvez pas utiliser cette commande, car un administrateur l'a désactivée !"
 close_title_sourcebin: "Transcription du ticket par iHorizon"
 close_description_sourcebin: " "
 close_error_command: "Une erreur s'est produite, veuillez réessayer !"
@@ -130,7 +130,7 @@ close_command_error: "Une erreur s'est produite, veuillez réessayer !"
 close_not_in_ticket: "Vous ne pouvez pas utiliser cette commande en dehors d'un ticket !"
 
 # /delete
-delete_disabled_command: "Vous ne pouvez pas utiliser cette commande car un administrateur a désactivé cette commande !"
+delete_disabled_command: "Vous ne pouvez pas utiliser cette commande, car un administrateur l'a désactivée !"
 delete_not_in_ticket: "Vous ne pouvez pas utiliser cette commande en dehors d'un ticket !"
 
 # /sethereticket
@@ -159,19 +159,19 @@ sethereticket_modal_2_fields_2_title: "Description de l'incorporation"
 sethereticket_panel_select_embed_desc: "# Nom du panneau\n```${result.panelName}```\n{msg}\n\n## Catégorie\n```{category}```\n"
 
 # /open
-open_disabled_command: "Vous ne pouvez pas utiliser cette commande car un administrateur a désactivé cette commande !"
+open_disabled_command: "Vous ne pouvez pas utiliser cette commande, car un administrateur l'a désactivée !"
 open_command_work: "Le ticket ${interaction.channel} a été réouvert avec succès."
 open_command_error: "Une erreur est survenue, veuillez réessayer!"
 open_not_in_ticket: "Vous ne pouvez pas utiliser cette commande en dehors d'un ticket !"
 
 # /remove
-remove_disabled_command: "Vous ne pouvez pas utiliser cette commande car un administrateur a désactivé cette commande !"
+remove_disabled_command: "Vous ne pouvez pas utiliser cette commande, car un administrateur l'a désactivée !"
 remove_not_in_ticket: "Vous ne pouvez pas utiliser cette commande en dehors d'un ticket !"
 remove_command_error: "Une erreur est survenue, veuillez réessayer !"
 remove_command_work: "${member.tag} a été retiré avec succès de votre ticket !"
 
 # /transcript
-transript_disabled_command: "Vous ne pouvez pas utiliser cette commande car un administrateur a désactivé cette commande !"
+transript_disabled_command: "Vous ne pouvez pas utiliser cette commande, car un administrateur l'a désactivée !"
 transript_name_sourcebin: " "
 transript_title_sourcebin: "Transcription du chat de ticket pour ${channel.name}"
 transript_command_error: "Une erreur s'est produite, veuillez réessayer !"
@@ -189,7 +189,7 @@ disableticket_command_work_enable: "Vous avez activé avec succès les commandes
 
 # /setticketcategory
 setticketcategory_not_admin: ":x: | Vous devez être un administrateur de ce serveur pour utiliser cette commande !"
-setticketcategory_disabled_command: "Vous ne pouvez pas utiliser cette commande car un administrateur a désactivé cette commande !"
+setticketcategory_disabled_command: "Vous ne pouvez pas utiliser cette commande, car un administrateur l'a désactivée !"
 setticketcategory_not_a_category: "Le salon spécifié n'est pas une catégorie, veuillez réessayer."
 setticketcategory_command_work: "<@${interaction.user.id}>, vous avez défini la catégorie du canal de ticket sur `${category.name}` !"
 

--- a/src/lang/fr-ME.yml
+++ b/src/lang/fr-ME.yml
@@ -112,15 +112,15 @@ perm_useexternalapps_name: "Utiliser des applications externes"
 
 # Ticket commands
 # /add, /close, /delete, /sethereticket, /open, /remove, /transript, /disableticket
-ticket_disabled_command: "Tu peux pas utilisé cette commande désolé mec ya un bouffon d'administrateur qui a désactivé les commandes de ticket!"
+ticket_disabled_command: "Tu peux pas utilisé cette commande désolé mec ya un bouffon d'administrateur l'a désactivé !"
 
 # /add
-add_disabled_command: "Tu peux pas utilisé cette commande désolé mec ya un bouffon d'administrateur qui a désactivé les commandes de ticket!"
+add_disabled_command: "Tu peux pas utilisé cette commande désolé mec ya un bouffon d'administrateur l'a désactivé !"
 add_command_work: "le mec ${member.tag} jlai bien ajouté au ticket !"
 add_command_error: "Erreur de merde , ressaie dans 1 ans."
 
 # /close
-close_disabled_command: "Tu peux pas utilisé cette commande désolé mec ya un bouffon d'administrateur qui a désactivé les commandes de ticket!"
+close_disabled_command: "Tu peux pas utilisé cette commande désolé mec ya un bouffon d'administrateur l'a désactivé !"
 close_title_sourcebin: "Transcription du ticket par iHorizon le thug"
 close_description_sourcebin: " "
 close_error_command: "Erreur de merde , ressaie dans 1 ans."
@@ -130,11 +130,11 @@ close_command_error: "Erreur de merde , ressaie dans 1 ans."
 close_not_in_ticket: "Tu peux pas utilisé cte commande si t pas dans un salon de ticket."
 
 # /delete
-delete_disabled_command: "Tu peux pas utilisé cette commande désolé mec ya un bouffon d'administrateur qui a désactivé les commandes de ticket!"
+delete_disabled_command: "Tu peux pas utilisé cette commande désolé mec ya un bouffon d'administrateur l'a désactivé !"
 delete_not_in_ticket: "Wsh t con tu peux pas utiliser la commande dans un autre salon qu'un salon de ticket !"
 
 # /sethereticket
-sethereticket_disabled_command: "Tu peux pas utilisé cette commande désolé mec ya un bouffon d'administrateur qui a désactivé les commandes de ticket!"
+sethereticket_disabled_command: "Tu peux pas utilisé cette commande désolé mec ya un bouffon d'administrateur l'a désactivé !"
 sethereticket_not_admin: ":x: | Tu dois etre le patron pour faire ca , allez dégage sale locataire."
 sethereticket_description_embed: "Clique sur cte icone si tu veux ouvrir un ticket pour devenir un puant de discord📩"
 sethereticket_command_work: "Wé c bon le paneau de ticket est config."
@@ -159,29 +159,29 @@ sethereticket_modal_2_fields_2_title: "Description de l'incorporation"
 sethereticket_panel_select_embed_desc: "# Nom du panneau\n```${result.panelName}```\n{msg}\n\n## Catégorie\n```{category}```\n"
 
 # /open
-open_disabled_command: "Tu peux pas utilisé cette commande désolé mec ya un bouffon d'administrateur qui a désactivé les commandes de ticket!"
+open_disabled_command: "Tu peux pas utilisé cette commande désolé mec ya un bouffon d'administrateur l'a désactivé !"
 open_command_work: "Le ticket ${interaction.channel} a été réouvert avec succès."
-open_command_error: "Une erreur est survenue, veuillez réessayer!"
+open_command_error: "Une erreur est survenue, réessaye bouffon"
 open_not_in_ticket: "Tu ne peux pas utiliser cette commande en dehors d'un salon de ticket!"
 
 # /remove
-remove_disabled_command: "Tu peux pas utilisé cette commande désolé mec ya un bouffon d'administrateur qui a désactivé les commandes de ticket!"
+remove_disabled_command: "Tu peux pas utilisé cette commande désolé mec ya un bouffon d'administrateur l'a désactivé !"
 remove_not_in_ticket: "Tu ne peux pas utiliser cette commande en dehors d'un canal de ticket !"
 remove_command_error: "Une erreur est survenue, veuillez réessayer !"
 remove_command_work: "${member.tag} a été retiré avec succès de ton ticket !"
 
 # /transript
-transript_disabled_command: "Tu peux pas utilisé cette commande désolé mec ya un bouffon d'administrateur qui a désactivé les commandes de ticket!"
+transript_disabled_command: "Tu peux pas utilisé cette commande désolé mec ya un bouffon d'administrateur l'a désactivé !"
 transript_name_sourcebin: " "
 transript_title_sourcebin: "Transcription du chat de ticket pour ${channel.name}"
 transript_command_error: "Erreur de merde , ressaie dans 1 ans."
-transript_command_work: "Tu as fermé ton ticket. Jvais t'envoyé la transcription."
+transript_command_work: "T'a fermé ton ticket. Jvais t'envoyé la transcription."
 transript_not_in_ticket: "Fait la commande dans un ticket ou jte fracasse !"
 
 # /disableticket
-disableticket_not_admin: ":x: | Tu devez être le patron du serveur pour utiliser cte commande !"
+disableticket_not_admin: ":x: | wesh t'a cru t'es le patron du serveur pour utiliser cte commande !"
 disableticket_logs_embed_title_disable: "Logs de désactivation des tickets au cas ou tu trappelle plus"
-disableticket_logs_embed_description_disable: "<@${interaction.user.id}> a désactivé les commandes de ticket il étais trooop guez !"
+disableticket_logs_embed_description_disable: "<@${interaction.user.id}> a désactivé lréessayees commandes de ticket il étais trooop guez !"
 disableticket_command_work_disable: "Ta désactivé les commandes de ticket mes couilles !"
 disableticket_logs_embed_title_enable: "Logs d'activation des tickets ct pourrit"
 disableticket_logs_embed_description_enable: "<@${interaction.user.id}> a activé les commandes de ticket il est pas con le tcho!"
@@ -189,8 +189,8 @@ disableticket_command_work_enable: "GG ta activé les commandes de ticket we we 
 
 # /setticketcategory
 setticketcategory_not_admin: ":x: | Tu dois avoir perm admin , et ouais va sucer les owners il te rankeront peut etre!"
-setticketcategory_disabled_command: "Tu peux pas utilisé cette commande désolé mec ya un bouffon d'administrateur qui a désactivé les commandes de ticket!"
-setticketcategory_not_a_category: "C pas une catégorie refait , sois moin con un peu nan?"
+setticketcategory_disabled_command: "Tu peux pas utilisé cette commande désolé mec ya un bouffon d'administrateur l'a désactivé !"
+setticketcategory_not_a_category: "C pas une catégorie refait , sois moin con un peu nan en vrai?"
 setticketcategory_command_work: "<@${interaction.user.id}>, tu as défini la catégorie du canal de ticket sur `${category.name}` !"
 
 # /ticket log-channel


### PR DESCRIPTION
Eviter les répétitions en remplaçant :
'Vous ne pouvez pas utiliser cette commande, car un administrateur a désactivé cette commande !' par :
'Vous ne pouvez pas utiliser cette commande, car un administrateur l'a désactivée !'

(update) 

même modification en anglais : 
Change
 You can't use this command because an Administrator disabled the ticket command!
to
You cannot use this command because an administrator has disabled it! 
to avoid repetitions.
