### PR TITLE
Ajout de l'explication Erreur 404 dans le AutoMod Mass Mention d'iHorizon

### DIFF
--- a/src/Interaction/SlashCommands/guildconfig/!mass-mention.ts
+++ b/src/Interaction/SlashCommands/guildconfig/!mass-mention.ts
@@ -106,7 +106,7 @@ export const subCommand: SubCommand = {
                 });
                 return;
             } catch (error) {
-                await interaction.editReply({ content: 'Error 404' });
+                await interaction.editReply({ content: 'Error 404' + lang.automod_block_massmention_command_error404 });
             }
         } else if (turn === "off") {
 

--- a/src/Interaction/SlashCommands/guildconfig/!mass-mention.ts
+++ b/src/Interaction/SlashCommands/guildconfig/!mass-mention.ts
@@ -106,7 +106,7 @@ export const subCommand: SubCommand = {
                 });
                 return;
             } catch (error) {
-                await interaction.editReply({ content: 'Error 404' + lang.automod_block_massmention_command_error404 });
+                await interaction.editReply({ content: 'Error 404. ' + lang.automod_block_massmention_command_error404 });
             }
         } else if (turn === "off") {
 

--- a/src/lang/ar-EG.yml
+++ b/src/lang/ar-EG.yml
@@ -1226,7 +1226,7 @@ joinghostping_remove_logs_embed_desc: "${interaction.user} قام بحذف ${cha
 # /automod block mass-mention
 automod_block_massmention_command_off: "${interaction.user}, لقد قمت بتعيين قاعدة AutoMod للـ `Mass-Mention` إلى **false**.\nالآن يمكن للمستخدمين إرسال الإشعارات في رسائلهم.\nAutoMod x iHorizon تم تعطيله في خادمك!"
 automod_block_massmention_command_on: "${interaction.user}, لقد قمت بتعيين قاعدة AutoMod للـ `Mass-Mention` إلى **true**.\nالآن لا يمكن للمستخدمين إرسال أكثر من **${max_mention}** إشعار في رسائلهم.\nAutoMod __يتم إرسال السجلات__ إلى ${logs_channel}.\nAutoMod x iHorizon يحمي خادمك!"
-
+automod_block_massmention_command_error404: ”هل تركت أمر حظر الإشارات المزعجة (ممكّن افتراضيًا بواسطة Discord) في إعدادات التعديل التلقائي، حيث إنه بالتأكيد مسؤول عن هذا الخطأ، يرجى تعطيله وتشغيل الأمر مرة أخرى.“ 
 
 # /automod block links
 automod_block_link_command_on: "${interaction.user}, لقد قمت بتفعيل قاعدة AutoMod لـ **حظر الروابط**. الآن، لا يمكن للمستخدمين إرسال روابط في رسائلهم. AutoMod __يتم إرسال السجلات__ إلى ${logs_channel}. AutoMod x iHorizon لحماية خادمك!"

--- a/src/lang/ar-EG.yml
+++ b/src/lang/ar-EG.yml
@@ -1226,7 +1226,7 @@ joinghostping_remove_logs_embed_desc: "${interaction.user} قام بحذف ${cha
 # /automod block mass-mention
 automod_block_massmention_command_off: "${interaction.user}, لقد قمت بتعيين قاعدة AutoMod للـ `Mass-Mention` إلى **false**.\nالآن يمكن للمستخدمين إرسال الإشعارات في رسائلهم.\nAutoMod x iHorizon تم تعطيله في خادمك!"
 automod_block_massmention_command_on: "${interaction.user}, لقد قمت بتعيين قاعدة AutoMod للـ `Mass-Mention` إلى **true**.\nالآن لا يمكن للمستخدمين إرسال أكثر من **${max_mention}** إشعار في رسائلهم.\nAutoMod __يتم إرسال السجلات__ إلى ${logs_channel}.\nAutoMod x iHorizon يحمي خادمك!"
-automod_block_massmention_command_error404: ”هل تركت أمر حظر الإشارات المزعجة (ممكّن افتراضيًا بواسطة Discord) في إعدادات التعديل التلقائي، حيث إنه بالتأكيد مسؤول عن هذا الخطأ، يرجى تعطيله وتشغيل الأمر مرة أخرى.“ 
+automod_block_massmention_command_error404: هل تركت أمر حظر الإشارات المزعجة (ممكّن افتراضيًا بواسطة Discord) في إعدادات التعديل التلقائي، حيث إنه بالتأكيد مسؤول عن هذا الخطأ، يرجى تعطيله وتشغيل الأمر مرة أخرى. 
 
 # /automod block links
 automod_block_link_command_on: "${interaction.user}, لقد قمت بتفعيل قاعدة AutoMod لـ **حظر الروابط**. الآن، لا يمكن للمستخدمين إرسال روابط في رسائلهم. AutoMod __يتم إرسال السجلات__ إلى ${logs_channel}. AutoMod x iHorizon لحماية خادمك!"

--- a/src/lang/de-DE.yml
+++ b/src/lang/de-DE.yml
@@ -1224,7 +1224,7 @@ joinghostping_remove_logs_embed_desc: "${interaction.user} hat ${channel} aus de
 # /automod block mass-mention
 automod_block_massmention_command_off: "${interaction.user}, du hast die `Massen-Erwähnungs-AutoMod-Regel` auf **false** gesetzt.\nJetzt können Benutzer Erwähnungen in ihren Nachrichten senden.\nAutoMod x iHorizon wurde auf deinem Server deaktiviert!"
 automod_block_massmention_command_on: "${interaction.user}, du hast die `Massen-Erwähnungs-AutoMod-Regel` auf **true** gesetzt.\nJetzt können Benutzer nicht mehr als **${max_mention}** Erwähnungen in ihren Nachrichten senden.\nAutoMod __sendet Protokolle__ in ${logs_channel}.\nAutoMod x iHorizon schützt deinen Server!"
-automod_block_massmention_command_error404: "Haben Sie Block Mention Spam (standardmäßig von Discord aktiviert) in den AutoMod-Einstellungen aktiviert gelassen, da dies wahrscheinlich für diesen Fehler verantwortlich ist, deaktivieren Sie es bitte und starten Sie die Bestellung erneut."
+automod_block_massmention_command_error404: Haben Sie Block Mention Spam (standardmäßig von Discord aktiviert) in den AutoMod-Einstellungen aktiviert gelassen, da dies wahrscheinlich für diesen Fehler verantwortlich ist, deaktivieren Sie es bitte und starten Sie die Bestellung erneut.
 
 # /automod block links
 automod_block_link_command_on: "${interaction.user}, Sie haben die `Pub AutoMod Rule` auf **true** gesetzt.\nNun können Benutzer keine Links in ihren Nachrichten senden.\nAutoMod __sendet Protokolle__ in ${logs_channel}.\nAutoMod x iHorizon schützt Ihren Server!"

--- a/src/lang/de-DE.yml
+++ b/src/lang/de-DE.yml
@@ -1224,6 +1224,7 @@ joinghostping_remove_logs_embed_desc: "${interaction.user} hat ${channel} aus de
 # /automod block mass-mention
 automod_block_massmention_command_off: "${interaction.user}, du hast die `Massen-Erwähnungs-AutoMod-Regel` auf **false** gesetzt.\nJetzt können Benutzer Erwähnungen in ihren Nachrichten senden.\nAutoMod x iHorizon wurde auf deinem Server deaktiviert!"
 automod_block_massmention_command_on: "${interaction.user}, du hast die `Massen-Erwähnungs-AutoMod-Regel` auf **true** gesetzt.\nJetzt können Benutzer nicht mehr als **${max_mention}** Erwähnungen in ihren Nachrichten senden.\nAutoMod __sendet Protokolle__ in ${logs_channel}.\nAutoMod x iHorizon schützt deinen Server!"
+automod_block_massmention_command_error404: "Haben Sie Block Mention Spam (standardmäßig von Discord aktiviert) in den AutoMod-Einstellungen aktiviert gelassen, da dies wahrscheinlich für diesen Fehler verantwortlich ist, deaktivieren Sie es bitte und starten Sie die Bestellung erneut."
 
 # /automod block links
 automod_block_link_command_on: "${interaction.user}, Sie haben die `Pub AutoMod Rule` auf **true** gesetzt.\nNun können Benutzer keine Links in ihren Nachrichten senden.\nAutoMod __sendet Protokolle__ in ${logs_channel}.\nAutoMod x iHorizon schützt Ihren Server!"

--- a/src/lang/en-US.yml
+++ b/src/lang/en-US.yml
@@ -1223,7 +1223,7 @@ joinghostping_remove_logs_embed_desc: "${interaction.user} have delete ${channel
 # /automod block mass-mention
 automod_block_massmention_command_off: "${interaction.user}, you have set the `Mass-Mention AutoMod Rule` to **false**.\nNow user can send mentions in their message.\nAutoMod x iHorizon have been disabled on your server!"
 automod_block_massmention_command_on: "${interaction.user}, you have set the `Mass-Mention AutoMod Rule` to **true**.\nNow user can't send more than **${max_mention}** mention(s) in their message.\nAutoMod __sending logs__ in ${logs_channel}.\nAutoMod x iHorizon protect your server!"
-automod_block_massmention_command_error404: “Did you leave Block Mention Spam enabled (enabled by default by Discord) in AutoMod settings, indeed it is surely responsible for this error, please disable it and run the command again.” 
+automod_block_massmention_command_error404: Did you leave Block Mention Spam enabled (enabled by default by Discord) in AutoMod settings, indeed it is surely responsible for this error, please disable it and run the command again. 
 
 # /automod block links
 automod_block_link_command_on: "${interaction.user}, you have set the `Pub AutoMod Rule` to **true**.\nNow users can't send links in their messages.\nAutoMod is now __sending logs__ in ${logs_channel}.\nAutoMod x iHorizon protect your server! "

--- a/src/lang/en-US.yml
+++ b/src/lang/en-US.yml
@@ -1223,6 +1223,7 @@ joinghostping_remove_logs_embed_desc: "${interaction.user} have delete ${channel
 # /automod block mass-mention
 automod_block_massmention_command_off: "${interaction.user}, you have set the `Mass-Mention AutoMod Rule` to **false**.\nNow user can send mentions in their message.\nAutoMod x iHorizon have been disabled on your server!"
 automod_block_massmention_command_on: "${interaction.user}, you have set the `Mass-Mention AutoMod Rule` to **true**.\nNow user can't send more than **${max_mention}** mention(s) in their message.\nAutoMod __sending logs__ in ${logs_channel}.\nAutoMod x iHorizon protect your server!"
+automod_block_massmention_command_error404: “Did you leave Block Mention Spam enabled (enabled by default by Discord) in AutoMod settings, indeed it is surely responsible for this error, please disable it and run the command again.” 
 
 # /automod block links
 automod_block_link_command_on: "${interaction.user}, you have set the `Pub AutoMod Rule` to **true**.\nNow users can't send links in their messages.\nAutoMod is now __sending logs__ in ${logs_channel}.\nAutoMod x iHorizon protect your server! "

--- a/src/lang/es-ES.yml
+++ b/src/lang/es-ES.yml
@@ -1224,7 +1224,7 @@ joinghostping_remove_logs_embed_desc: "${interaction.user} ha eliminado ${channe
 # /automod block mass-mention
 automod_block_massmention_command_off: "${interaction.user}, has desactivado la regla de `AutoModeración de Menciones Masivas` a **falso**.\nAhora los usuarios pueden enviar menciones en sus mensajes.\nAutoModeración x iHorizon ha sido desactivada en tu servidor."
 automod_block_massmention_command_on: "${interaction.user}, has activado la regla de `AutoModeración de Menciones Masivas` a **verdadero**.\nAhora los usuarios no pueden enviar más de **${max_mention}** mención(es) en sus mensajes.\nAutoModeración __enviando registros__ en ${logs_channel}.\nAutoModeración x iHorizon protege tu servidor!"
-automod_block_massmention_command_error404: "¿Has dejado activado Block Mention Spam (activado por defecto por Discord) en la configuración de AutoMod, ya que seguramente es el responsable de este error, por favor desactívalo y ejecuta el comando de nuevo."
+automod_block_massmention_command_error404: ¿Has dejado activado Block Mention Spam (activado por defecto por Discord) en la configuración de AutoMod, ya que seguramente es el responsable de este error, por favor desactívalo y ejecuta el comando de nuevo.
 
 # /automod block links
 automod_block_link_command_on: "${interaction.user}, has establecido la `Regla de AutoMod Pub` en **true**.\nAhora los usuarios no pueden enviar enlaces en sus mensajes.\nAutoMod __envía registros__ en ${logs_channel}.\n¡AutoMod x iHorizon protege tu servidor!"

--- a/src/lang/es-ES.yml
+++ b/src/lang/es-ES.yml
@@ -1224,6 +1224,7 @@ joinghostping_remove_logs_embed_desc: "${interaction.user} ha eliminado ${channe
 # /automod block mass-mention
 automod_block_massmention_command_off: "${interaction.user}, has desactivado la regla de `AutoModeración de Menciones Masivas` a **falso**.\nAhora los usuarios pueden enviar menciones en sus mensajes.\nAutoModeración x iHorizon ha sido desactivada en tu servidor."
 automod_block_massmention_command_on: "${interaction.user}, has activado la regla de `AutoModeración de Menciones Masivas` a **verdadero**.\nAhora los usuarios no pueden enviar más de **${max_mention}** mención(es) en sus mensajes.\nAutoModeración __enviando registros__ en ${logs_channel}.\nAutoModeración x iHorizon protege tu servidor!"
+automod_block_massmention_command_error404: "¿Has dejado activado Block Mention Spam (activado por defecto por Discord) en la configuración de AutoMod, ya que seguramente es el responsable de este error, por favor desactívalo y ejecuta el comando de nuevo."
 
 # /automod block links
 automod_block_link_command_on: "${interaction.user}, has establecido la `Regla de AutoMod Pub` en **true**.\nAhora los usuarios no pueden enviar enlaces en sus mensajes.\nAutoMod __envía registros__ en ${logs_channel}.\n¡AutoMod x iHorizon protege tu servidor!"

--- a/src/lang/fr-FR.yml
+++ b/src/lang/fr-FR.yml
@@ -1224,6 +1224,7 @@ joinghostping_remove_logs_embed_desc: "${interaction.user} a supprimé ${channel
 # /automod block mass-mention
 automod_block_massmention_command_off: "${interaction.user}, vous avez désactivé la règle `AutoModération de Mention Massive` à **false**.\nMaintenant, les utilisateurs peuvent envoyer des mentions dans leurs messages.\nAutoMod x iHorizon a été désactivé sur votre serveur !"
 automod_block_massmention_command_on: "${interaction.user}, vous avez activé la règle `AutoModération de Mention Massive` à **true**.\nMaintenant, les utilisateurs ne peuvent pas envoyer plus de **${max_mention}** mention(s) dans leurs messages.\nAutoMod __envoie des journaux__ dans ${logs_channel}.\nAutoMod x iHorizon protège votre serveur !"
+automod_block_massmention_command_error404: "Avez-vous laissé activé Block Mention Spam (activé par défaut par Discord) dans les paramètres AutoMod, en effet il est sûrement responsable de cet erreur, veuillez le désactiver et relancer la commande à nouveau." 
 
 # /automod block links
 automod_block_link_command_on: "${interaction.user}, vous avez activé la `Règle AutoMod Pub` sur **true**.\nLes utilisateurs ne peuvent plus envoyer de liens dans leurs messages.\nAutoMod __envoie des journaux__ dans ${logs_channel}.\nAutoMod x iHorizon protège votre serveur!"

--- a/src/lang/fr-FR.yml
+++ b/src/lang/fr-FR.yml
@@ -1224,7 +1224,7 @@ joinghostping_remove_logs_embed_desc: "${interaction.user} a supprimé ${channel
 # /automod block mass-mention
 automod_block_massmention_command_off: "${interaction.user}, vous avez désactivé la règle `AutoModération de Mention Massive` à **false**.\nMaintenant, les utilisateurs peuvent envoyer des mentions dans leurs messages.\nAutoMod x iHorizon a été désactivé sur votre serveur !"
 automod_block_massmention_command_on: "${interaction.user}, vous avez activé la règle `AutoModération de Mention Massive` à **true**.\nMaintenant, les utilisateurs ne peuvent pas envoyer plus de **${max_mention}** mention(s) dans leurs messages.\nAutoMod __envoie des journaux__ dans ${logs_channel}.\nAutoMod x iHorizon protège votre serveur !"
-automod_block_massmention_command_error404: "Avez-vous laissé activé Block Mention Spam (activé par défaut par Discord) dans les paramètres AutoMod, en effet il est sûrement responsable de cet erreur, veuillez le désactiver et relancer la commande à nouveau." 
+automod_block_massmention_command_error404: "Avez-vous laissé activé Block Mention Spam (activé par défaut par Discord) dans les paramètres AutoMod, en effet il est sûrement responsable de cette erreur, veuillez le désactiver et relancer la commande à nouveau." 
 
 # /automod block links
 automod_block_link_command_on: "${interaction.user}, vous avez activé la `Règle AutoMod Pub` sur **true**.\nLes utilisateurs ne peuvent plus envoyer de liens dans leurs messages.\nAutoMod __envoie des journaux__ dans ${logs_channel}.\nAutoMod x iHorizon protège votre serveur!"

--- a/src/lang/fr-FR.yml
+++ b/src/lang/fr-FR.yml
@@ -1224,7 +1224,7 @@ joinghostping_remove_logs_embed_desc: "${interaction.user} a supprimé ${channel
 # /automod block mass-mention
 automod_block_massmention_command_off: "${interaction.user}, vous avez désactivé la règle `AutoModération de Mention Massive` à **false**.\nMaintenant, les utilisateurs peuvent envoyer des mentions dans leurs messages.\nAutoMod x iHorizon a été désactivé sur votre serveur !"
 automod_block_massmention_command_on: "${interaction.user}, vous avez activé la règle `AutoModération de Mention Massive` à **true**.\nMaintenant, les utilisateurs ne peuvent pas envoyer plus de **${max_mention}** mention(s) dans leurs messages.\nAutoMod __envoie des journaux__ dans ${logs_channel}.\nAutoMod x iHorizon protège votre serveur !"
-automod_block_massmention_command_error404: "Avez-vous laissé activé Block Mention Spam (activé par défaut par Discord) dans les paramètres AutoMod, en effet il est sûrement responsable de cette erreur, veuillez le désactiver et relancer la commande à nouveau." 
+automod_block_massmention_command_error404: Avez-vous laissé activé Block Mention Spam (activé par défaut par Discord) dans les paramètres AutoMod, en effet il est sûrement responsable de cette erreur, veuillez le désactiver et relancer la commande à nouveau. 
 
 # /automod block links
 automod_block_link_command_on: "${interaction.user}, vous avez activé la `Règle AutoMod Pub` sur **true**.\nLes utilisateurs ne peuvent plus envoyer de liens dans leurs messages.\nAutoMod __envoie des journaux__ dans ${logs_channel}.\nAutoMod x iHorizon protège votre serveur!"

--- a/src/lang/fr-ME.yml
+++ b/src/lang/fr-ME.yml
@@ -1224,6 +1224,7 @@ joinghostping_remove_logs_embed_desc: "${interaction.user} a supprimé ${channel
 # /automod block mass-mention
 automod_block_massmention_command_off: "${interaction.user}, tu as désactivé la règle `AutoModération de Mention Massive` à **false**.\nMaintenant, les utilisateurs peuvent envoyer des mentions dans leurs messages.\nAutoMod x iHorizon a été désactivé sur ton serveur !"
 automod_block_massmention_command_on: "${interaction.user}, tu as activé la règle `AutoModération de Mention Massive` à **true**.\nMaintenant, les utilisateurs ne peuvent pas envoyer plus de **${max_mention}** mention(s) dans leurs messages.\nAutoMod __envoie des journaux__ dans ${logs_channel}.\nAutoMod x iHorizon protège ton serveur !"
+automod_block_massmention_command_error404: "Trou du cul, désactive Block Mass Mention car ce connard entre en conflit avec MON propre système, DÉSACTIVE MOI ÇA J'AI DIT et relance la commande, c'est bon ???"
 
 # /automod block links
 automod_block_link_command_on: "${interaction.user}, vous avez activé la `Règle AutoMod Pub` sur **true**.\nLes utilisateurs ne peuvent plus envoyer de liens dans leurs messages.\nAutoMod __envoie des journaux__ dans ${logs_channel}.\nAutoMod x iHorizon protège votre serveur!"

--- a/src/lang/fr-ME.yml
+++ b/src/lang/fr-ME.yml
@@ -1224,7 +1224,7 @@ joinghostping_remove_logs_embed_desc: "${interaction.user} a supprimé ${channel
 # /automod block mass-mention
 automod_block_massmention_command_off: "${interaction.user}, tu as désactivé la règle `AutoModération de Mention Massive` à **false**.\nMaintenant, les utilisateurs peuvent envoyer des mentions dans leurs messages.\nAutoMod x iHorizon a été désactivé sur ton serveur !"
 automod_block_massmention_command_on: "${interaction.user}, tu as activé la règle `AutoModération de Mention Massive` à **true**.\nMaintenant, les utilisateurs ne peuvent pas envoyer plus de **${max_mention}** mention(s) dans leurs messages.\nAutoMod __envoie des journaux__ dans ${logs_channel}.\nAutoMod x iHorizon protège ton serveur !"
-automod_block_massmention_command_error404: "Trou du cul, désactive Block Mass Mention car ce connard entre en conflit avec MON propre système, DÉSACTIVE MOI ÇA J'AI DIT et relance la commande, c'est bon ???"
+automod_block_massmention_command_error404: Trou du cul, désactive Block Mass Mention car ce connard entre en conflit avec MON propre système, DÉSACTIVE MOI ÇA J'AI DIT et relance la commande, c'est bon ???
 
 # /automod block links
 automod_block_link_command_on: "${interaction.user}, vous avez activé la `Règle AutoMod Pub` sur **true**.\nLes utilisateurs ne peuvent plus envoyer de liens dans leurs messages.\nAutoMod __envoie des journaux__ dans ${logs_channel}.\nAutoMod x iHorizon protège votre serveur!"

--- a/src/lang/it-IT.yml
+++ b/src/lang/it-IT.yml
@@ -1224,7 +1224,7 @@ joinghostping_remove_logs_embed_desc: "${interaction.user} ha rimosso ${channel}
 # /automod block mass-mention
 automod_block_massmention_command_off: "${interaction.user}, hai impostato la regola `AutoMod Mass Mention` su **false**.\nOra gli utenti possono inviare menzioni nei loro messaggi.\nAutoMod x iHorizon è stato disattivato nel tuo server!"
 automod_block_massmention_command_on: "${interaction.user}, hai impostato la regola `AutoMod Mass Mention` su **true**.\nOra gli utenti non possono inviare più di **${max_mention}** menzioni nei loro messaggi.\nAutoMod __invia registri__ in ${logs_channel}.\nAutoMod x iHorizon protegge il tuo server!"
-automod_block_massmention_command_error404: "Hai lasciato Block Mention Spam abilitato (abilitato per impostazione predefinita da Discord) nelle impostazioni di AutoMod, poiché è sicuramente responsabile di questo errore, per favore disabilitalo ed esegui di nuovo il comando." 
+automod_block_massmention_command_error404: Hai lasciato Block Mention Spam abilitato (abilitato per impostazione predefinita da Discord) nelle impostazioni di AutoMod, poiché è sicuramente responsabile di questo errore, per favore disabilitalo ed esegui di nuovo il comando. 
 
 # /automod block links
 automod_block_link_command_on: "${interaction.user}, hai impostato la `Regola AutoMod Pub` su **true**.\nOra gli utenti non possono inviare link nei loro messaggi.\nAutoMod __invia log__ in ${logs_channel}.\nAutoMod x iHorizon protegge il tuo server!"

--- a/src/lang/it-IT.yml
+++ b/src/lang/it-IT.yml
@@ -1224,6 +1224,7 @@ joinghostping_remove_logs_embed_desc: "${interaction.user} ha rimosso ${channel}
 # /automod block mass-mention
 automod_block_massmention_command_off: "${interaction.user}, hai impostato la regola `AutoMod Mass Mention` su **false**.\nOra gli utenti possono inviare menzioni nei loro messaggi.\nAutoMod x iHorizon è stato disattivato nel tuo server!"
 automod_block_massmention_command_on: "${interaction.user}, hai impostato la regola `AutoMod Mass Mention` su **true**.\nOra gli utenti non possono inviare più di **${max_mention}** menzioni nei loro messaggi.\nAutoMod __invia registri__ in ${logs_channel}.\nAutoMod x iHorizon protegge il tuo server!"
+automod_block_massmention_command_error404: "Hai lasciato Block Mention Spam abilitato (abilitato per impostazione predefinita da Discord) nelle impostazioni di AutoMod, poiché è sicuramente responsabile di questo errore, per favore disabilitalo ed esegui di nuovo il comando." 
 
 # /automod block links
 automod_block_link_command_on: "${interaction.user}, hai impostato la `Regola AutoMod Pub` su **true**.\nOra gli utenti non possono inviare link nei loro messaggi.\nAutoMod __invia log__ in ${logs_channel}.\nAutoMod x iHorizon protegge il tuo server!"

--- a/src/lang/jp-JP.yml
+++ b/src/lang/jp-JP.yml
@@ -1224,7 +1224,8 @@ joinghostping_remove_logs_embed_desc: "${interaction.user} が Join GhostPing �
 # /automod block mass-mention
 automod_block_massmention_command_off: "${interaction.user}, あなたは`Mass-Mention AutoModルール`を**false**に設定しました。\n今、ユーザーはメッセージにメンションを送信できます。\nAutoMod x iHorizonはサーバーで無効になっています！"
 automod_block_massmention_command_on: "${interaction.user}, あなたは`Mass-Mention AutoModルール`を**true**に設定しました。\n今、ユーザーはメッセージに**${max_mention}**回以上のメンションを送信できません。\nAutoModは${logs_channel}にログを送信しています。\nAutoMod x iHorizonがサーバーを保護しています！"
-automod_block_massmention_command_error404: "AutoMod設定でBlock Mention Spamを有効にしたままにしていませんか（Discordではデフォルトで有効になっています）。"
+automod_block_massmention_command_error404: AutoMod設定でBlock Mention Spamを有効にしたままにしていませんか（Discordではデフォルトで有効になっています）。
+
 # /automod block links
 automod_block_link_command_on: "${interaction.user}、`Pub AutoModルール`を**true**に設定しました。\nこれでユーザーはメッセージにリンクを送信できません。\nAutoModは${logs_channel}に__ログを送信__します。\nAutoMod x iHorizonはあなたのサーバーを保護します！"
 automod_block_link_command_off: "${interaction.user}、`Pub AutoModルール`を**false**に設定しました。\nこれでユーザーはメッセージにリンクを送信できます。\nAutoMod x iHorizonはあなたのサーバーで無効になりました！"

--- a/src/lang/jp-JP.yml
+++ b/src/lang/jp-JP.yml
@@ -1224,7 +1224,7 @@ joinghostping_remove_logs_embed_desc: "${interaction.user} が Join GhostPing �
 # /automod block mass-mention
 automod_block_massmention_command_off: "${interaction.user}, あなたは`Mass-Mention AutoModルール`を**false**に設定しました。\n今、ユーザーはメッセージにメンションを送信できます。\nAutoMod x iHorizonはサーバーで無効になっています！"
 automod_block_massmention_command_on: "${interaction.user}, あなたは`Mass-Mention AutoModルール`を**true**に設定しました。\n今、ユーザーはメッセージに**${max_mention}**回以上のメンションを送信できません。\nAutoModは${logs_channel}にログを送信しています。\nAutoMod x iHorizonがサーバーを保護しています！"
-
+automod_block_massmention_command_error404: "AutoMod設定でBlock Mention Spamを有効にしたままにしていませんか（Discordではデフォルトで有効になっています）。"
 # /automod block links
 automod_block_link_command_on: "${interaction.user}、`Pub AutoModルール`を**true**に設定しました。\nこれでユーザーはメッセージにリンクを送信できません。\nAutoModは${logs_channel}に__ログを送信__します。\nAutoMod x iHorizonはあなたのサーバーを保護します！"
 automod_block_link_command_off: "${interaction.user}、`Pub AutoModルール`を**false**に設定しました。\nこれでユーザーはメッセージにリンクを送信できます。\nAutoMod x iHorizonはあなたのサーバーで無効になりました！"

--- a/src/lang/pt-PT.yml
+++ b/src/lang/pt-PT.yml
@@ -1224,7 +1224,7 @@ joinghostping_remove_logs_embed_desc: "${interaction.user} removeu ${channel} do
 # /automod block mass-mention
 automod_block_massmention_command_off: "${interaction.user}, você configurou a `Regra AutoMod de Mencionamento em Massa` para **false**.\nAgora os usuários podem enviar menções em suas mensagens.\nAutoMod x iHorizon foi desativado no seu servidor!"
 automod_block_massmention_command_on: "${interaction.user}, você configurou a `Regra AutoMod de Mencionamento em Massa` para **true**.\nAgora os usuários não podem enviar mais de **${max_mention}** menção(ões) em suas mensagens.\nAutoMod __enviando logs__ em ${logs_channel}.\nAutoMod x iHorizon protege o seu servidor!"
-automod_block_massmention_command_error404: “Deixaste o Block Mention Spam ativado (ativado por defeito pelo Discord) nas definições do AutoMod, pois é certamente responsável por este erro, por favor desactiva-o e executa o comando novamente.” 
+automod_block_massmention_command_error404: Deixaste o Block Mention Spam ativado (ativado por defeito pelo Discord) nas definições do AutoMod, pois é certamente responsável por este erro, por favor desactiva-o e executa o comando novamente. 
 
 # /automod block links
 automod_block_link_command_on: "${interaction.user}, você configurou a `Regra AutoMod Pub` para **true**.\nAgora, os usuários não podem enviar links em suas mensagens.\nAutoMod __enviando logs__ em ${logs_channel}.\nAutoMod x iHorizon protege seu servidor!"

--- a/src/lang/pt-PT.yml
+++ b/src/lang/pt-PT.yml
@@ -1224,6 +1224,7 @@ joinghostping_remove_logs_embed_desc: "${interaction.user} removeu ${channel} do
 # /automod block mass-mention
 automod_block_massmention_command_off: "${interaction.user}, você configurou a `Regra AutoMod de Mencionamento em Massa` para **false**.\nAgora os usuários podem enviar menções em suas mensagens.\nAutoMod x iHorizon foi desativado no seu servidor!"
 automod_block_massmention_command_on: "${interaction.user}, você configurou a `Regra AutoMod de Mencionamento em Massa` para **true**.\nAgora os usuários não podem enviar mais de **${max_mention}** menção(ões) em suas mensagens.\nAutoMod __enviando logs__ em ${logs_channel}.\nAutoMod x iHorizon protege o seu servidor!"
+automod_block_massmention_command_error404: “Deixaste o Block Mention Spam ativado (ativado por defeito pelo Discord) nas definições do AutoMod, pois é certamente responsável por este erro, por favor desactiva-o e executa o comando novamente.” 
 
 # /automod block links
 automod_block_link_command_on: "${interaction.user}, você configurou a `Regra AutoMod Pub` para **true**.\nAgora, os usuários não podem enviar links em suas mensagens.\nAutoMod __enviando logs__ em ${logs_channel}.\nAutoMod x iHorizon protege seu servidor!"

--- a/src/lang/ru-RU.yml
+++ b/src/lang/ru-RU.yml
@@ -1224,6 +1224,7 @@ joinghostping_remove_logs_embed_desc: "${interaction.user} удалил ${channe
 # /automod block mass-mention
 automod_block_massmention_command_off: "${interaction.user}, вы отключили `Правило автоматической модерации упоминаний` и теперь пользователи могут отправлять упоминания в своих сообщениях.\nAutoMod x iHorizon отключен на вашем сервере!"
 automod_block_massmention_command_on: "${interaction.user}, вы включили `Правило автоматической модерации упоминаний` и теперь пользователи не могут отправлять более **${max_mention}** упоминаний в своих сообщениях.\nAutoMod отправляет журналы в ${logs_channel}.\nAutoMod x iHorizon защищает ваш сервер!"
+automod_block_massmention_command_error404: "Не оставили ли вы включенной функцию Block Mention Spam (по умолчанию включена Discord) в настройках AutoMod, так как она, несомненно, ответственна за эту ошибку, пожалуйста, отключите ее и запустите команду снова."
 
 # /automod block links
 automod_block_link_command_on: "${interaction.user}, вы установили `Pub AutoMod Rule` на **true**.\nТеперь пользователи не могут отправлять ссылки в своих сообщениях.\nAutoMod __отправляет логи__ в ${logs_channel}.\nAutoMod x iHorizon защищает ваш сервер!"

--- a/src/lang/ru-RU.yml
+++ b/src/lang/ru-RU.yml
@@ -1224,7 +1224,7 @@ joinghostping_remove_logs_embed_desc: "${interaction.user} удалил ${channe
 # /automod block mass-mention
 automod_block_massmention_command_off: "${interaction.user}, вы отключили `Правило автоматической модерации упоминаний` и теперь пользователи могут отправлять упоминания в своих сообщениях.\nAutoMod x iHorizon отключен на вашем сервере!"
 automod_block_massmention_command_on: "${interaction.user}, вы включили `Правило автоматической модерации упоминаний` и теперь пользователи не могут отправлять более **${max_mention}** упоминаний в своих сообщениях.\nAutoMod отправляет журналы в ${logs_channel}.\nAutoMod x iHorizon защищает ваш сервер!"
-automod_block_massmention_command_error404: "Не оставили ли вы включенной функцию Block Mention Spam (по умолчанию включена Discord) в настройках AutoMod, так как она, несомненно, ответственна за эту ошибку, пожалуйста, отключите ее и запустите команду снова."
+automod_block_massmention_command_error404: Не оставили ли вы включенной функцию Block Mention Spam (по умолчанию включена Discord) в настройках AutoMod, так как она, несомненно, ответственна за эту ошибку, пожалуйста, отключите ее и запустите команду снова.
 
 # /automod block links
 automod_block_link_command_on: "${interaction.user}, вы установили `Pub AutoMod Rule` на **true**.\nТеперь пользователи не могут отправлять ссылки в своих сообщениях.\nAutoMod __отправляет логи__ в ${logs_channel}.\nAutoMod x iHorizon защищает ваш сервер!"

--- a/types/languageData.d.ts
+++ b/types/languageData.d.ts
@@ -969,6 +969,7 @@ export interface LanguageData {
   automod_block_pub_command_off: string;
   automod_block_spam_command_on: string;
   automod_block_spam_command_off: string;
+  automod_block_massmention_command_error404: string;
   too_new_account_dont_specified_time_on_enable: string;
   too_new_account_invalid_time_on_enable: string;
   too_new_account_logEmbed_title: string;


### PR DESCRIPTION
J'ai ajouté une explication de l'Erreur 404 qui arrive des fois lors de l'exécution de la commande `/automod block mass-mention`

Au moins, on ne nous demandera pas la raison, car elle y sera :)

Bon, par contre, je n'ai pas testé mes changements, mais normalement ça doit marcher. Je le mets aussi en Draft le temps que j'ajoute les autres langues (sous-entendu, j'ai la flemme mdr).
