### PR TITLE
Ajout de l'extension .js au chemin d'importation de ConfigData

### DIFF
--- a/src/files/config.example.ts
+++ b/src/files/config.example.ts
@@ -19,7 +19,7 @@
 ・ Copyright © 2020-2025 iHorizon
 */
 
-import { ConfigData } from '../../types/configDatad';
+import { ConfigData } from '../../types/configDatad.js';
 
 const config: ConfigData = {
 


### PR DESCRIPTION
J'ai ajouté l'extension de fichier '.js' au chemin d'importation de `ConfigData` dans le fichier ``config.example.ts`` pour corriger l'erreur de résolution de module dans l'importation ECMAScript que j'avais eu quand je faisais des tests avec le Bot :)