### PR TITLE
Changement du temps maximal de l'AutoRenew

### DIFF
--- a/src/Interaction/HybridCommands/utils/!autorenew.ts
+++ b/src/Interaction/HybridCommands/utils/!autorenew.ts
@@ -53,12 +53,12 @@ export const subCommand: SubCommand = {
 
 		let parseTime = client.timeCalculator.to_ms(time || "");
 
-		if (parseTime && parseTime < 60_000) {
+		if (parseTime && parseTime < 60_000) { // Ceci est égal à 1 minute
 			await client.func.method.interactionSend(interaction, {
 				content: lang.util_autorenew_time_too_short
 			})
 			return;
-		} else if (parseTime && parseTime > 60_000 * 60 * 24) {
+		} else if (parseTime && parseTime > 2629800000) { // Ceci est égal à 1 mois (30 jours)
 			await client.func.method.interactionSend(interaction, {
 				content: lang.util_autorenew_time_too_long
 			})


### PR DESCRIPTION
Ce changement fait en sorte que le temps maximal de l'AutoRenew est égal à 30 jours (2629800000 millisecondes) à la place des 24h précedemment. Aussi, j'ai rajouté 2 petits commentaires de code pour aider certains s'ils regardent le code.